### PR TITLE
Support zero length string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/koron/go-mqtt
 
 go 1.25.0
 
-require golang.org/x/net v0.56.0
+require (
+	github.com/google/go-cmp v0.7.0
+	golang.org/x/net v0.56.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=

--- a/packet/connect_test.go
+++ b/packet/connect_test.go
@@ -1,65 +1,162 @@
 package packet
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestConnect1(t *testing.T) {
-	data := []byte{
-		0x10,
-		61,
-		0, // Length MSB (0)
-		4, // Length LSB (4)
-		'M', 'Q', 'T', 'T',
-		4,   // Protocol level 4
-		206, // connect flags 11001110, will QoS = 01
-		0,   // Keep Alive MSB (0)
-		10,  // Keep Alive LSB (10)
-		0,   // Client ID MSB (0)
-		7,   // Client ID LSB (7)
-		'g', 'o', '-', 'm', 'q', 't', 't',
-		0, // Will Topic MSB (0)
-		4, // Will Topic LSB (4)
-		'w', 'i', 'l', 'l',
-		0,  // Will Message MSB (0)
-		12, // Will Message LSB (12)
-		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
-		0, // Username ID MSB (0)
-		8, // Username ID LSB (7)
-		'u', 's', 'e', 'r', 'n', 'a', 'm', 'e',
-		0,  // Password ID MSB (0)
-		10, // Password ID LSB (10)
-		'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
-	}
-	p := Connect{}
-	err := p.Decode(data)
+func testConnect(t *testing.T, data []byte, want Connect) {
+	t.Helper()
+
+	// Decode test
+	got := Connect{}
+	err := got.Decode(data)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if !reflect.DeepEqual(Connect{
-		ClientID:     "go-mqtt",
-		Version:      4,
-		Username:     str2ptr("username"),
-		Password:     str2ptr("verysecret"),
-		CleanSession: true,
-		KeepAlive:    10,
-		WillFlag:     true,
-		WillQoS:      QAtLeastOnce,
-		WillRetain:   false,
-		WillTopic:    "will",
-		WillMessage:  "send me home",
-	}, p) {
-		t.Fatalf("mismatch Connect:\n actual=%+v", p)
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("unexpected decoded Connect: -want +got\n%s", d)
 	}
 
-	// encode test.
-	b, err := p.Encode()
+	// Encode test
+	b, err := got.Encode()
 	if err != nil {
 		t.Fatal(err)
 	}
-	compareBytes(t, b, data)
+	if d := cmp.Diff(data, b); d != "" {
+		t.Errorf("unexpected encoded Connect: -want +got\n%s", d)
+	}
+}
+
+func TestConnect(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		testConnect(t,
+			[]byte{
+				0x10,
+				61,
+				0, // Length MSB (0)
+				4, // Length LSB (4)
+				'M', 'Q', 'T', 'T',
+				4,    // Protocol level 4
+				0xce, // connect flags 11001110, will QoS = 01
+				0,    // Keep Alive MSB (0)
+				10,   // Keep Alive LSB (10)
+				0,    // Client ID MSB (0)
+				7,    // Client ID LSB (7)
+				'g', 'o', '-', 'm', 'q', 't', 't',
+				0, // Will Topic MSB (0)
+				4, // Will Topic LSB (4)
+				'w', 'i', 'l', 'l',
+				0,  // Will Message MSB (0)
+				12, // Will Message LSB (12)
+				's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+				0, // Username ID MSB (0)
+				8, // Username ID LSB (7)
+				'u', 's', 'e', 'r', 'n', 'a', 'm', 'e',
+				0,  // Password ID MSB (0)
+				10, // Password ID LSB (10)
+				'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
+			},
+			Connect{
+				ClientID:     "go-mqtt",
+				Version:      4,
+				Username:     str2ptr("username"),
+				Password:     str2ptr("verysecret"),
+				CleanSession: true,
+				KeepAlive:    10,
+				WillFlag:     true,
+				WillQoS:      QAtLeastOnce,
+				WillRetain:   false,
+				WillTopic:    "will",
+				WillMessage:  "send me home",
+			},
+		)
+	})
+
+	t.Run("empty username and password", func(t *testing.T) {
+		testConnect(t,
+			[]byte{
+				0x10,
+				43,
+				0, // Length MSB (0)
+				4, // Length LSB (4)
+				'M', 'Q', 'T', 'T',
+				4,    // Protocol level 4
+				0xce, // connect flags 11001110, will QoS = 01
+				0,    // Keep Alive MSB (0)
+				10,   // Keep Alive LSB (10)
+				0,    // Client ID MSB (0)
+				7,    // Client ID LSB (7)
+				'g', 'o', '-', 'm', 'q', 't', 't',
+				0, // Will Topic MSB (0)
+				4, // Will Topic LSB (4)
+				'w', 'i', 'l', 'l',
+				0,  // Will Message MSB (0)
+				12, // Will Message LSB (12)
+				's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+				0, // Username ID MSB (0)
+				0, // Username ID LSB (0)
+				// zero-length username
+				0, // Password ID MSB (0)
+				0, // Password ID LSB (0)
+				// zero-length password
+			},
+			Connect{
+				ClientID:     "go-mqtt",
+				Version:      4,
+				Username:     str2ptr(""),
+				Password:     str2ptr(""),
+				CleanSession: true,
+				KeepAlive:    10,
+				WillFlag:     true,
+				WillQoS:      QAtLeastOnce,
+				WillRetain:   false,
+				WillTopic:    "will",
+				WillMessage:  "send me home",
+			},
+		)
+	})
+
+	t.Run("empty username without password", func(t *testing.T) {
+		testConnect(t,
+			[]byte{
+				0x10,
+				41,
+				0, // Length MSB (0)
+				4, // Length LSB (4)
+				'M', 'Q', 'T', 'T',
+				4,    // Protocol level 4
+				0x8e, // connect flags 10001110, will QoS = 01
+				0,    // Keep Alive MSB (0)
+				10,   // Keep Alive LSB (10)
+				0,    // Client ID MSB (0)
+				7,    // Client ID LSB (7)
+				'g', 'o', '-', 'm', 'q', 't', 't',
+				0, // Will Topic MSB (0)
+				4, // Will Topic LSB (4)
+				'w', 'i', 'l', 'l',
+				0,  // Will Message MSB (0)
+				12, // Will Message LSB (12)
+				's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+				0, // Username ID MSB (0)
+				0, // Username ID LSB (0)
+			},
+			Connect{
+				ClientID:     "go-mqtt",
+				Version:      4,
+				Username:     str2ptr(""),
+				Password:     nil,
+				CleanSession: true,
+				KeepAlive:    10,
+				WillFlag:     true,
+				WillQoS:      QAtLeastOnce,
+				WillRetain:   false,
+				WillTopic:    "will",
+				WillMessage:  "send me home",
+			},
+		)
+	})
 }
 
 func TestConnACK1(t *testing.T) {

--- a/packet/decode.go
+++ b/packet/decode.go
@@ -158,6 +158,9 @@ func (d *decoder) readString() (string, error) {
 		}
 		return "", err
 	}
+	if ul == 0 {
+		return "", nil
+	}
 	l := int(ul)
 	b := make([]byte, l)
 	n, err := d.r.Read(b)


### PR DESCRIPTION
`Decoder.readString()` has been modified to accept strings with a length of 0 bytes. Therefore, if the calling code does not support 0-byte strings, it is the caller's responsibility to perform the necessary checks.

This will be addressed in the future; no action is being taken at this time.

This change is a reimplementation of
https://github.com/koron/go-mqtt/pull/15.

---

Fix #15